### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 Udacity/generating_messages.py"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # script_kiddie
 Sandbox for simple python scripts
+
+
+[![Run on Repl.it](https://repl.it/badge/github/Coolfield/script_kiddie)](https://repl.it/github/Coolfield/script_kiddie)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).